### PR TITLE
fix(Readme): changes --accountToken to --token

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ As an alternative to the Project API token you can also send coverage using your
 
 ```json
 "scripts": {
-  "test-with-coverage": "cat ./coverage/lcov.info | codacy-coverage --accountToken <account-token> --username <username> --projectName <project-name>"
+  "test-with-coverage": "cat ./coverage/lcov.info | codacy-coverage --token <account-token> --username <username> --projectName <project-name>"
 }
 ```
 


### PR DESCRIPTION
Using --accountToken gives the following error:

```[error] "2018-09-21T08:12:17.182Z"  'Status Code [404] - Error [{"error":"not found"}]'
[error] "2018-09-21T08:12:17.187Z"  'Error sending coverage'
[error] "2018-09-21T08:12:17.187Z"  Error: Expected Successful Status Code, but got [404]```

However token works